### PR TITLE
Feature/suggest most recent date as version

### DIFF
--- a/src/main/java/de/eitco/mavenizer/analyze/JarAnalyzer.java
+++ b/src/main/java/de/eitco/mavenizer/analyze/JarAnalyzer.java
@@ -53,10 +53,12 @@ public class JarAnalyzer {
 	
 	public static class JarEntry {
 		public final Path path;// relative to jar root
-		public final FileTime timestamp;
-		public JarEntry(Path path, FileTime createdAt) {
+		public final FileTime timestampCreatedAt;
+		public final FileTime timestampLastModifiedAt;
+		public JarEntry(Path path, FileTime createdAt, FileTime lastModifiedAt) {
 			this.path = path;
-			this.timestamp = createdAt;
+			this.timestampCreatedAt = createdAt;
+			this.timestampLastModifiedAt = lastModifiedAt;
 		}
 	}
 	
@@ -207,11 +209,7 @@ public class JarAnalyzer {
 				}
 			}
 			if (filenameLower.endsWith(".class")) {
-				var timestamp = entry.getCreationTime();
-				if (timestamp == null) {
-					timestamp = entry.getLastModifiedTime();
-				}
-				onClass.accept(new JarEntry(entryPath, timestamp));
+				onClass.accept(new JarEntry(entryPath, entry.getCreationTime(), entry.getLastModifiedTime()));
 			}
 			if (Paths.get("META-INF/MANIFEST.MF").equals(entryPath)) {
 				try {

--- a/src/main/java/de/eitco/mavenizer/analyze/jar/ClassTimestampAnalyzer.java
+++ b/src/main/java/de/eitco/mavenizer/analyze/jar/ClassTimestampAnalyzer.java
@@ -7,6 +7,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map.Entry;
 
+import org.apache.commons.lang3.ObjectUtils;
+
 import de.eitco.mavenizer.MavenUid.MavenUidComponent;
 import de.eitco.mavenizer.StringUtil;
 import de.eitco.mavenizer.analyze.JarAnalyzer.JarAnalyzerType;
@@ -24,8 +26,9 @@ public class ClassTimestampAnalyzer {
 		var total = 0;
 		
 		for (var entry : classes) {
-			if (entry.timestamp != null) {
-				var instant = entry.timestamp.toInstant();
+			var lastChange = ObjectUtils.max(entry.timestampCreatedAt, entry.timestampLastModifiedAt);
+			if (lastChange != null) {
+				var instant = lastChange.toInstant();
 				var dateUtc = LocalDate.ofInstant(instant, ZoneOffset.UTC);
 				var count = datesToOccurence.getOrDefault(dateUtc, 0);
 				datesToOccurence.put(dateUtc, count + 1);

--- a/src/main/java/de/eitco/mavenizer/analyze/jar/ClassTimestampAnalyzer.java
+++ b/src/main/java/de/eitco/mavenizer/analyze/jar/ClassTimestampAnalyzer.java
@@ -24,6 +24,7 @@ public class ClassTimestampAnalyzer {
 		
 		var datesToOccurence = new HashMap<LocalDate, Integer>();
 		var total = 0;
+		LocalDate lastChangeDateAllClasses = null;
 		
 		for (var entry : classes) {
 			var lastChange = ObjectUtils.max(entry.timestampCreatedAt, entry.timestampLastModifiedAt);
@@ -33,9 +34,18 @@ public class ClassTimestampAnalyzer {
 				var count = datesToOccurence.getOrDefault(dateUtc, 0);
 				datesToOccurence.put(dateUtc, count + 1);
 				total++;
+
+				lastChangeDateAllClasses = ObjectUtils.max(lastChangeDateAllClasses, dateUtc);
 			}
 		}
 		
+		if (lastChangeDateAllClasses != null) {
+			var version = lastChangeDateAllClasses.format(dateToVersion);
+			var details = "most recent created/modified date of all classes: " + lastChangeDateAllClasses.format(datePrinter);
+
+			result.addCandidate(MavenUidComponent.VERSION, version, 2, details);
+		}
+
 		var highestCountEntry = 
 				datesToOccurence.entrySet().stream()
 			    .sorted(Entry.<LocalDate, Integer>comparingByValue().reversed())


### PR DESCRIPTION
I encoutered the case that a third party *.jar file was available in two different version. They both had the same file name, same metadata, 99% the same files including the same "created at" / "modified at" dates. Only two *.class files had a newer "created at" file date than the rest. So far Mavenizer would suggest the same version number for both *.jar files based on the "created at" / "modified at" file date that the majority of the *.class files have.

This PR adds another suggestion with the weight 2 based on the most current "created at" / "modified at" files dates for **all** *.class files found. I decided to use the weight of 2 since imho this suggestion is more valuable than just using the most common date found.